### PR TITLE
Reconstruction on demand

### DIFF
--- a/Ntupler/BuildFile.xml
+++ b/Ntupler/BuildFile.xml
@@ -40,6 +40,7 @@
 <!-- SUBSTRUCTRE -->
 <use name="RecoJets/JetAlgorithms"/>
 <!--  -->
+<use name="PandaUtilities/Common"/>
 <use name="PandaProd/Objects"/>
 <use name="PandaProd/Utilities"/>
 <use name="clhep"/>

--- a/Ntupler/interface/BaseFiller.h
+++ b/Ntupler/interface/BaseFiller.h
@@ -14,9 +14,20 @@ class BaseFiller
         virtual int  analyze(const edm::Event &) = 0 ;
         virtual int  analyze(const edm::Event &iEvent,const edm::EventSetup& iSetup) { return analyze(iEvent) ; } ;
         virtual inline string name(){return "BaseFiller";};
+        virtual void endJob() { return; }
         virtual void init(TTree *t) = 0;
 
         bool *skipEvent=0;
+        bool *reduceEvent=0;
+
+        /**
+         * \brief Skip the event if the pointer is set and false
+         */
+        bool SkipEvent() { return ((skipEvent!=0) && (*skipEvent)); }
+        /**
+         * \brief Reduce the event content if the pointer is set and false
+         */
+        bool ReduceEvent() { return ((reduceEvent!=0) && (*reduceEvent)); }
 };
 }
 #endif

--- a/Ntupler/interface/Includes.h
+++ b/Ntupler/interface/Includes.h
@@ -55,6 +55,9 @@ using namespace std;
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"
 #include "PhysicsTools/PatUtils/interface/TriggerHelper.h"
 
+// PANDA
+
+#include "PandaUtilities/Common/interface/Common.h"
 
 // ROOT
 #include "TTree.h"

--- a/Ntupler/interface/Ntupler.h
+++ b/Ntupler/interface/Ntupler.h
@@ -30,7 +30,7 @@ class Ntupler : public edm::EDAnalyzer {
         panda::InfoFiller *info; // this saves the all tree
         panda::EventFiller *event; // this goes into obj, but is also used in beginJob()
 
-        bool *skipEvent;
+        bool *skipEvent, *reduceEvent;
 };
 
 

--- a/Ntupler/interface/RecoilFilter.h
+++ b/Ntupler/interface/RecoilFilter.h
@@ -1,0 +1,60 @@
+#ifndef RecoilFilter_H
+#define RecoilFilter_H
+
+#include "BaseFiller.h"
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+#include <map>
+#include <string>
+
+
+namespace panda {
+class RecoilFilter : virtual public BaseFiller
+{
+    public:
+        RecoilFilter(TString n);
+        ~RecoilFilter();
+        int analyze(const edm::Event& iEvent);
+        virtual inline string name(){return "RecoilFilter";};
+        virtual void endJob();
+        void init(TTree *t);
+
+        edm::EDGetTokenT<pat::METCollection> met_token ;    
+        edm::Handle<pat::METCollection> met_handle;
+
+        edm::EDGetTokenT<pat::METCollection> puppimet_token;
+        edm::Handle<pat::METCollection> puppimet_handle;
+
+        edm::EDGetTokenT<pat::MuonCollection> mu_token;
+        edm::Handle<pat::MuonCollection> mu_handle;
+
+        edm::EDGetTokenT<pat::ElectronCollection> el_token;
+        edm::Handle<pat::ElectronCollection> el_handle;
+
+        edm::EDGetTokenT<pat::PhotonCollection> ph_token;
+        edm::Handle<pat::PhotonCollection> ph_handle;
+
+        float minU=150;
+
+    private:
+        bool isGoodMuon(const pat::Muon&);
+        bool isGoodElectron(const pat::Electron&);
+        bool isGoodPhoton(const pat::Photon&); 
+
+        TString treename;
+        float maxRecoil=0;
+        int whichRecoil=-1; //!< = 2*RecoilType + METType
+
+        int nTotal=0, nAcc=0;
+};
+}
+
+
+#endif

--- a/Ntupler/python/PandaProd_cfi.py
+++ b/Ntupler/python/PandaProd_cfi.py
@@ -19,6 +19,7 @@ PandaNtupler = cms.EDAnalyzer("Ntupler",
 
     # offline skimming
     doJetSkim = cms.bool(False),
+    doRecoilFilter = cms.bool(True),
 
     # jet toggles
     savePuppiCands = cms.bool(False),
@@ -39,11 +40,9 @@ PandaNtupler = cms.EDAnalyzer("Ntupler",
 
     pfmet = cms.InputTag("slimmedMETs"),
     puppimet = cms.InputTag("slimmedMETsPuppi"),
-    # metsPuppiUncorrected = cms.InputTag("pfMETPuppi"), # should be removed soon, going to be deprecated
 
     puppiPFCands = cms.InputTag("puppi"),
     chsPFCands = cms.InputTag('packedPFCandidates'),
-    #chsPFCands = cms.InputTag('pfCHS'),
 
     # egm stuffs
     eleEA = cms.string("RecoEgamma/ElectronIdentification/data/Summer16/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_80X.txt"),
@@ -111,7 +110,6 @@ PandaNtupler = cms.EDAnalyzer("Ntupler",
     metfilterPaths = cms.vstring([
                                   'Flag_HBHENoiseFilter', 
                                   'Flag_HBHENoiseIsoFilter', 
-                                  'Flag_CSCTightHalo2015Filter', 
                                   'Flag_EcalDeadCellTriggerPrimitiveFilter', 
                                   'Flag_goodVertices', 
                                   'Flag_eeBadScFilter',

--- a/Ntupler/src/EventFiller.cc
+++ b/Ntupler/src/EventFiller.cc
@@ -46,6 +46,7 @@ int EventFiller::analyze(const edm::Event& iEvent){
 
       unsigned int nP = trigger_paths.size();
       if (data->isData) {
+        data->tiggers->clear(); // just in case, so the next line initializes to false
         data->tiggers->resize(trigger_paths.size(),false);
 
         iEvent.getByToken(trigger_token,trigger_handle);      
@@ -53,6 +54,8 @@ int EventFiller::analyze(const edm::Event& iEvent){
 
         unsigned int nT = tn.size();
         for (unsigned int iT=0; iT!=nT; ++iT) {
+          if (!trigger_handle->accept(iT))
+            continue;
           string name = tn.triggerName(iT);
           for (unsigned int jP=0; jP!=nP; ++jP) {
             if (name.find(trigger_paths[jP]) != string::npos) {

--- a/Ntupler/src/FatJetFiller.cc
+++ b/Ntupler/src/FatJetFiller.cc
@@ -87,9 +87,8 @@ int FatJetFiller::analyze(const edm::Event& iEvent){
       delete d;
     data->clear();
 
-    if (skipEvent!=0 && *skipEvent) {
+    if (SkipEvent())
       return 0;
-    }
 
     iEvent.getByToken(jet_token, jet_handle);
     iEvent.getByToken(rho_token,rho_handle);
@@ -179,7 +178,7 @@ int FatJetFiller::analyze(const edm::Event& iEvent){
         }
       }
 
-      if (pfcands!=0 || (!minimal && data->size()<2)) {
+      if (!ReduceEvent() && (pfcands!=0 || (!minimal && data->size()<2))) {
         // either we want to associate to pf cands OR compute extra info about the first or second jet
 
         std::vector<edm::Ptr<reco::Candidate>> constituentPtrs = j.getJetConstituents();

--- a/Ntupler/src/RecoilFilter.cc
+++ b/Ntupler/src/RecoilFilter.cc
@@ -1,0 +1,143 @@
+#include "PandaProd/Ntupler/interface/RecoilFilter.h"
+
+using namespace panda;
+
+RecoilFilter::RecoilFilter(TString n):
+    BaseFiller()
+{
+  treename = n;
+}
+
+RecoilFilter::~RecoilFilter(){
+}
+
+void RecoilFilter::init(TTree *t) {
+  t->Branch("filter_maxRecoil",&maxRecoil,"filter_maxRecoil/F");
+  t->Branch("filter_whichRecoil",&whichRecoil,"filter_whichRecoil/I");
+}
+
+bool RecoilFilter::isGoodMuon(const pat::Muon& muon){
+    if (muon.pt()<15) return false;
+    if (not muon.isLooseMuon()) return false;
+    if (muon.pfIsolationR04().sumChargedHadronPt/muon.pt()>0.12) return false;
+    return true;
+}
+
+bool RecoilFilter::isGoodElectron(const pat::Electron& ele){
+    if (ele.pt()<15) return false;
+    if (ele.chargedHadronIso()/ele.pt()>0.1) return false;
+    bool isEB = ele.isEB();
+    bool isEE = ele.isEE();
+    if (isEB and ele.full5x5_sigmaIetaIeta()>0.011) return false;
+    if (isEE and ele.full5x5_sigmaIetaIeta()>0.030) return false;
+    return true;
+}
+
+bool RecoilFilter::isGoodPhoton(const pat::Photon& photon){
+    if (photon.chargedHadronIso()>10) return false;
+    if (not photon.isEB()) return false;
+    if (photon.full5x5_sigmaIetaIeta()>0.020) return false;
+    return true;
+}
+
+void RecoilFilter::endJob() {
+  PInfo("PandaProd::RecoilFilter",TString::Format("Accepted %i/%i events",nAcc,nTotal));
+}
+
+int RecoilFilter::analyze(const edm::Event& iEvent){
+    bool keep=false;
+    maxRecoil = -1;
+    whichRecoil = -1;
+    ++nTotal;
+
+    using namespace edm;
+    iEvent.getByToken(met_token, met_handle);
+    iEvent.getByToken(puppimet_token, puppimet_handle);
+    iEvent.getByToken(mu_token, mu_handle);
+    iEvent.getByToken(el_token, el_handle);
+    iEvent.getByToken(ph_token, ph_handle);
+
+    std::vector<reco::Candidate::LorentzVector> mets;
+    for (auto met = met_handle->begin(); met!=met_handle->end(); met++){
+        mets.push_back(met->p4());
+    }
+
+    for (auto met = puppimet_handle->begin(); met!=puppimet_handle->end(); met++) {
+        mets.push_back(met->p4());
+    }
+    
+    float U=0;
+    for (unsigned iM=0; iM!=2; ++iM) {
+        reco::Candidate::LorentzVector met = mets.at(iM);
+        U = met.pt();
+        maxRecoil = std::max((float)U,maxRecoil);
+        if (U>minU) {
+          keep = true;
+          whichRecoil = 2*0+iM;
+        }
+        
+        // loop over leptons to get W+jets events
+        for (pat::MuonCollection::const_iterator muon = mu_handle->begin(); muon!=mu_handle->end(); muon++){
+            if (not isGoodMuon(*muon)) continue;
+            U = (met+muon->p4()).pt();
+            maxRecoil = std::max((float)U,maxRecoil);
+            if (U>minU) {
+              keep = true;
+              whichRecoil = 2*1+iM;
+            }
+        }
+        for (pat::ElectronCollection::const_iterator ele = el_handle->begin(); ele!=el_handle->end(); ele++){
+            if (not isGoodElectron(*ele)) continue;
+            U = (met+ele->p4()).pt();
+            maxRecoil = std::max((float)U,maxRecoil);
+            if (U>minU) {
+              keep = true;
+              whichRecoil = 2*2+iM;
+            }
+        }
+
+        // loop over dilepton pairs
+        for (unsigned int imuon=0; imuon+1<mu_handle->size(); imuon++){
+            if (not isGoodMuon(mu_handle->at(imuon))) continue;
+            for (unsigned int jmuon=imuon+1; jmuon<mu_handle->size(); jmuon++){
+                if (not isGoodMuon(mu_handle->at(jmuon))) continue;
+                U = (met+mu_handle->at(imuon).p4()+mu_handle->at(jmuon).p4()).pt();
+                maxRecoil = std::max((float)U,maxRecoil);
+                if (U>minU) {
+                  keep = true;
+                  whichRecoil = 2*3+iM;
+                }
+            }           
+        }
+        for (unsigned int iele=0; iele+1<el_handle->size(); iele++){
+            if (not isGoodElectron(el_handle->at(iele))) continue;
+            for (unsigned int jele=iele+1; jele<el_handle->size(); jele++){
+                if (not isGoodElectron(el_handle->at(jele))) continue;
+                U = (met+el_handle->at(iele).p4()+el_handle->at(jele).p4()).pt();
+                maxRecoil = std::max((float)U,maxRecoil);
+                if (U>minU) {
+                  keep = true;
+                  whichRecoil = 2*4+iM;
+                }
+            }           
+        }
+            
+        for (unsigned int ipho=0; ipho<ph_handle->size(); ipho++){
+            if (not isGoodPhoton(ph_handle->at(ipho))) continue;
+            U = (met+ph_handle->at(ipho).p4()).pt();
+            maxRecoil = std::max((float)U,maxRecoil);
+            if (U>minU) {
+              keep = true;
+              whichRecoil = 2*5+iM;
+            }
+        }
+    }
+
+    *reduceEvent = !keep;
+
+    if (keep)
+      ++nAcc;
+  
+    return 0;
+}
+

--- a/Ntupler/src/RecoilFilter.cc
+++ b/Ntupler/src/RecoilFilter.cc
@@ -70,29 +70,35 @@ int RecoilFilter::analyze(const edm::Event& iEvent){
     for (unsigned iM=0; iM!=2; ++iM) {
         reco::Candidate::LorentzVector met = mets.at(iM);
         U = met.pt();
-        maxRecoil = std::max((float)U,maxRecoil);
+        if (U>maxRecoil)
+          maxRecoil = U;
+          whichRecoil = 2*0+iM;
+        }
         if (U>minU) {
           keep = true;
-          whichRecoil = 2*0+iM;
         }
         
         // loop over leptons to get W+jets events
         for (pat::MuonCollection::const_iterator muon = mu_handle->begin(); muon!=mu_handle->end(); muon++){
             if (not isGoodMuon(*muon)) continue;
             U = (met+muon->p4()).pt();
-            maxRecoil = std::max((float)U,maxRecoil);
+            if (U>maxRecoil) {
+              maxRecoil = U;
+              whichRecoil = 2*1+iM;
+            }
             if (U>minU) {
               keep = true;
-              whichRecoil = 2*1+iM;
             }
         }
         for (pat::ElectronCollection::const_iterator ele = el_handle->begin(); ele!=el_handle->end(); ele++){
             if (not isGoodElectron(*ele)) continue;
             U = (met+ele->p4()).pt();
-            maxRecoil = std::max((float)U,maxRecoil);
+            if (U>maxRecoil) {
+              maxRecoil = U;
+              whichRecoil = 2*2+iM;
+            }
             if (U>minU) {
               keep = true;
-              whichRecoil = 2*2+iM;
             }
         }
 
@@ -102,10 +108,12 @@ int RecoilFilter::analyze(const edm::Event& iEvent){
             for (unsigned int jmuon=imuon+1; jmuon<mu_handle->size(); jmuon++){
                 if (not isGoodMuon(mu_handle->at(jmuon))) continue;
                 U = (met+mu_handle->at(imuon).p4()+mu_handle->at(jmuon).p4()).pt();
-                maxRecoil = std::max((float)U,maxRecoil);
+                if (U>maxRecoil) {
+                  maxRecoil = U;
+                  whichRecoil = 2*3+iM;
+                }
                 if (U>minU) {
                   keep = true;
-                  whichRecoil = 2*3+iM;
                 }
             }           
         }
@@ -114,10 +122,12 @@ int RecoilFilter::analyze(const edm::Event& iEvent){
             for (unsigned int jele=iele+1; jele<el_handle->size(); jele++){
                 if (not isGoodElectron(el_handle->at(jele))) continue;
                 U = (met+el_handle->at(iele).p4()+el_handle->at(jele).p4()).pt();
-                maxRecoil = std::max((float)U,maxRecoil);
+                if (U>maxRecoil) {
+                  maxRecoil = U;
+                  whichRecoil = 2*4+iM;
+                }
                 if (U>minU) {
                   keep = true;
-                  whichRecoil = 2*4+iM;
                 }
             }           
         }
@@ -125,10 +135,12 @@ int RecoilFilter::analyze(const edm::Event& iEvent){
         for (unsigned int ipho=0; ipho<ph_handle->size(); ipho++){
             if (not isGoodPhoton(ph_handle->at(ipho))) continue;
             U = (met+ph_handle->at(ipho).p4()).pt();
-            maxRecoil = std::max((float)U,maxRecoil);
+            if (U>maxRecoil) {
+              maxRecoil = U;
+              whichRecoil = 2*5+iM;
+            }
             if (U>minU) {
               keep = true;
-              whichRecoil = 2*5+iM;
             }
         }
     }

--- a/Ntupler/test/runNtupler.py
+++ b/Ntupler/test/runNtupler.py
@@ -326,7 +326,7 @@ process.p = cms.Path(
                         process.puppiMETSequence *             # builds all the puppi collections
                         process.egmPhotonIDSequence *          # baseline photon ID for puppi correction
                         process.fullPatMetSequencePuppi *      # puppi MET
-                        process.monoXFilterSequence *          # filter
+                        # process.monoXFilterSequence *          # filter
                         process.jetSequence *                  # patify ak4puppi and do all fatjet stuff
                         process.metfilterSequence *
                         process.PandaNtupler

--- a/Ntupler/test/submitCrab.py
+++ b/Ntupler/test/submitCrab.py
@@ -43,7 +43,7 @@ config.Data.splitting = 'FileBased'
 config.Data.unitsPerJob = 10
 config.Data.totalUnits = -1
 
-config.Data.outLFNDirBase = '/store/group/phys_exotica/monotop/pandaprod/v6/' 
+config.Data.outLFNDirBase = '/store/group/phys_exotica/monotop/pandaprod/v_8022_0/' 
 #config.Data.outLFNDirBase = '/store/user/%s/scramjet/' % (getUsernameFromSiteDB())
 config.Data.publication = False
 config.Data.outputDatasetTag ='PandA'
@@ -89,8 +89,7 @@ if __name__ == '__main__':
             config.Data.splitting = 'LumiBased'
             #config.Data.lumiMask=None
             url = "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/"
-            config.Data.lumiMask = url + "Cert_271036-276811_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt"
-            #config.Data.lumiMask = '/afs/cern.ch/work/s/snarayan/private/CMSSW_8_0_11/src/NeroProducer/Nero/test/jsons/toprocess.json'
+            config.Data.lumiMask = url + "Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         else:
             config.Data.lumiMask = None
             config.Data.splitting = 'FileBased'
@@ -121,31 +120,47 @@ if __name__ == '__main__':
     #############################################################################################
     
     ###################################################
-    ########            25ns  2016             ########
-    ###################################################
     setdata("True")
     ###################################################
-    '''
+    config.Data.unitsPerJob = 50
+
+    submitList([
+            '/MET/Run2016B-23Sep2016-v2/MINIAOD',
+            '/MET/Run2016B-23Sep2016-v3/MINIAOD',
+            '/MET/Run2016C-23Sep2016-v1/MINIAOD',
+            '/MET/Run2016D-23Sep2016-v1/MINIAOD',
+            '/MET/Run2016E-23Sep2016-v1/MINIAOD',
+            '/MET/Run2016F-23Sep2016-v1/MINIAOD',
+            '/MET/Run2016G-23Sep2016-v1/MINIAOD',
+            '/MET/Run2016H-PromptReco-v1/MINIAOD',
+            '/MET/Run2016H-PromptReco-v2/MINIAOD',
+            '/MET/Run2016H-PromptReco-v3/MINIAOD',
+        ])
+    
     config.Data.unitsPerJob = 40
 
     submitList([
-            '/MET/Run2016D-PromptReco-v2/MINIAOD',
-            '/MET/Run2016C-PromptReco-v2/MINIAOD',
-            '/MET/Run2016B-PromptReco-v2/MINIAOD',
-        ])
-    
-    config.Data.unitsPerJob = 30
-
-    submitList([
-        '/SingleElectron/Run2016D-PromptReco-v2/MINIAOD',
-        '/SingleElectron/Run2016C-PromptReco-v2/MINIAOD',
-        '/SingleElectron/Run2016B-PromptReco-v2/MINIAOD',
-        #'/DoubleEG/Run2016B-PromptReco-v2/MINIAOD',
-        '/SinglePhoton/Run2016D-PromptReco-v2/MINIAOD',
-        '/SinglePhoton/Run2016C-PromptReco-v2/MINIAOD',
-        '/SinglePhoton/Run2016B-PromptReco-v2/MINIAOD',
-        ])
-    '''
+        '/SingleElectron/Run2016B-23Sep2016-v2/MINIAOD',
+        '/SingleElectron/Run2016B-23Sep2016-v3/MINIAOD',
+        '/SingleElectron/Run2016C-23Sep2016-v1/MINIAOD',
+        '/SingleElectron/Run2016D-23Sep2016-v1/MINIAOD',
+        '/SingleElectron/Run2016E-23Sep2016-v1/MINIAOD',
+        '/SingleElectron/Run2016F-23Sep2016-v1/MINIAOD',
+        '/SingleElectron/Run2016G-23Sep2016-v1/MINIAOD',
+        '/SinglePhoton/Run2016B-23Sep2016-v1/MINIAOD',
+        '/SinglePhoton/Run2016B-23Sep2016-v3/MINIAOD',
+        '/SinglePhoton/Run2016C-23Sep2016-v1/MINIAOD',
+        '/SinglePhoton/Run2016D-23Sep2016-v1/MINIAOD',
+        '/SinglePhoton/Run2016E-23Sep2016-v1/MINIAOD',
+        '/SinglePhoton/Run2016F-23Sep2016-v1/MINIAOD',
+        '/SinglePhoton/Run2016G-23Sep2016-v1/MINIAOD',
+        '/SingleElectron/Run2016H-PromptReco-v1/MINIAOD',
+        '/SingleElectron/Run2016H-PromptReco-v2/MINIAOD',
+        '/SingleElectron/Run2016H-PromptReco-v3/MINIAOD',
+        '/SinglePhoton/Run2016H-PromptReco-v1/MINIAOD',
+        '/SinglePhoton/Run2016H-PromptReco-v2/MINIAOD',
+        '/SinglePhoton/Run2016H-PromptReco-v3/MINIAOD',
+      ])
 
     ###################################################
     setdata("False")
@@ -154,10 +169,7 @@ if __name__ == '__main__':
     config.Data.splitting = 'EventAwareLumiBased'
     config.Data.unitsPerJob = 20000
     submitList([
-           '/WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-    ])
-
-    '''
+        '/WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
         '/TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
         '/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
@@ -169,15 +181,18 @@ if __name__ == '__main__':
         '/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
         '/DYJetsToLL_M-50_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-    '''
+    ])
 
-    '''
+
     ###################################################
     setdata("False")
     ###################################################
 
+    config.Data.splitting = 'FileBased'
     config.Data.unitsPerJob = 1
     submitList([ 
+        '/WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
+        '/WJetsToLNu_HT-2500ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/DYJetsToLL_M-50_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
@@ -185,9 +200,7 @@ if __name__ == '__main__':
         '/DYJetsToLL_M-50_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/ZJetsToNuNu_HT-800To1200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v3/MINIAODSIM',
         '/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
         '/ZJetsToNuNu_HT-2500ToInf_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/WJetsToLNu_Pt-600ToInf_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext4-v1/MINIAODSIM',
         '/QCD_HT2000toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/QCD_HT1500to2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v3/MINIAODSIM',
@@ -197,25 +210,17 @@ if __name__ == '__main__':
 
     config.Data.unitsPerJob = 2
     submitList([ 
+        '/WJetsToLNu_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
+        '/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
+        '/WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
+        '/WJetsToLNu_HT-600To800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v4/MINIAODSIM',
         '/GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-        '/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-        '/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
         '/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/DYJetsToLL_M-50_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
         '/ZJetsToNuNu_HT-200To400_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/ZJetsToNuNu_HT-200To400_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
         '/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-        '/ZJetsToNuNu_HT-600To800_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/WJetsToLNu_Pt-100To250_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/WJetsToLNu_Pt-250To400_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        '/WJetsToLNu_Pt-400To600_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM',
@@ -233,107 +238,7 @@ if __name__ == '__main__':
         '/ZprimeToA0hToA0chichihbb_2HDM_MZp-1000_MA0-300_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/ZprimeToA0hToA0chichihbb_2HDM_MZp-800_MA0-300_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
         '/ZprimeToA0hToA0chichihbb_2HDM_MZp-1200_MA0-300_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 
-        '/TTbarDMJets_pseudoscalar_Mchi-1_Mphi-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
         '/TT_TuneEE5C_13TeV-powheg-herwigpp/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM'
     ])
 
-    '''
-    '''
-    submitList([
-           '/WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-           '/WJetsToLNu_HT-2500ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-           '/WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-        ])
 
-    config.Data.unitsPerJob = 2
-
-    submitList([
-           '/WJetsToLNu_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-           '/WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-           '/WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-           '/WJetsToLNu_HT-600To800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        ])
-    '''
-
-    '''
-    submitList([ 
-            '/ZprimeToTTJet_M-1000_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToTTJet_M-1250_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToTTJet_M-1500_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToTTJet_M-2000_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToTTJet_M-2500_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToTTJet_M-3000_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToTTJet_M-3500_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToTTJet_M-4000_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToTTJet_M-500_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToTTJet_M-750_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-
-            '/ZprimeToWW_narrow_M-1000_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToWW_narrow_M-1200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToWW_narrow_M-1400_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToWW_narrow_M-1600_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToWW_narrow_M-1800_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToWW_narrow_M-2000_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToWW_narrow_M-2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZprimeToWW_narrow_M-800_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-
-           '/QCD_HT100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-           '/ZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v2/MINIAODSIM'
-           '/EWKZ2Jets_ZToNuNu_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-           '/EWKWMinus2Jets_WToLNu_M-50_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM',
-           '/EWKWPlus2Jets_WToLNu_M-50_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-           '/EWKZ2Jets_ZToLL_M-50_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M1000_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M110_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M150_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M200_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M300_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M400_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M500_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M600_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/VBF_HToInvisible_M800_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/tZq_ll_4f_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-            '/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v4/MINIAODSIM',
-            '/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3_ext1-v1/MINIAODSIM',
-            '/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-            '/ZJetsToNuNu_HT-1200To2500_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/ZJetsToNuNu_HT-2500ToInf_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/WJetsToLNu_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-            '/GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v4/MINIAODSIM',
-            '/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-            '/ZJetsToNuNu_HT-400To600_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-            '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/WJetsToLNu_Pt-100To250_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/WJetsToLNu_Pt-250To400_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/WJetsToLNu_Pt-400To600_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/WJetsToLNu_Pt-600ToInf_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-                #V1,
-            '/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM'    ,
-            '/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM',
-                #V1,
-            '/ZJetsToNuNu_HT-100To200_13TeV-madgraph/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3_ext1-v2/MINIAODSIM',
-                #V1,
-            '/ZJetsToNuNu_HT-200To400_13TeV-madgraph/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3_ext1-v1/MINIAODSIM',
-            '/ZJetsToNuNu_HT-600To800_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-                #V1,
-            '/ZJetsToNuNu_HT-800To1200_13TeV-madgraph/RunIISpring16MiniAODv1-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/MINIAODSIM',
-            '/GJets_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v4/MINIAODSIM',
-            '/GJets_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-            '/GJets_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',
-        ])
-    '''
-
-# Local Variables:
-# mode:python
-# indent-tabs-mode:nil
-# tab-width:4
-# c-basic-offset:4
-# End:
-# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/Ntupler/test/submitCrab.py
+++ b/Ntupler/test/submitCrab.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
         if value=='True':
             config.Data.splitting = 'LumiBased'
             #config.Data.lumiMask=None
-            url = "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/"
+            url = "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/"
             config.Data.lumiMask = url + "Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         else:
             config.Data.lumiMask = None

--- a/Ntupler/test/testNtupler.py
+++ b/Ntupler/test/testNtupler.py
@@ -23,9 +23,9 @@ isData = options.isData
 process.load("FWCore.MessageService.MessageLogger_cfi")
 # If you run over many samples and you save the log, remember to reduce
 # the size of the output by prescaling the report of the event number
-process.MessageLogger.cerr.FwkReport.reportEvery = 1
+process.MessageLogger.cerr.FwkReport.reportEvery = 10
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(200) )
 
 if isData:
    fileList = [
@@ -328,7 +328,7 @@ process.p = cms.Path(
                         process.puppiMETSequence *             # builds all the puppi collections
                         process.egmPhotonIDSequence *          # baseline photon ID for puppi correction
                         process.fullPatMetSequencePuppi *      # puppi MET
-                        process.monoXFilterSequence *          # filter
+                        # process.monoXFilterSequence *          # filter
                         process.jetSequence *                  # patify ak4puppi and do all fatjet stuff
                         process.metfilterSequence *
                         process.PandaNtupler

--- a/Utilities/interface/EnergyCorrelations.h
+++ b/Utilities/interface/EnergyCorrelations.h
@@ -1,3 +1,8 @@
+/**
+ * \file EnergyCorrelations.h
+ * \brief Optimized code to calculate energy correlation functions. Based on code from fj-contrib
+ * \author S.Narayanan
+ */
 #include "fastjet/PseudoJet.hh"
 #include <vector>
 #include <map>
@@ -8,103 +13,32 @@
 #ifndef ECF_H
 #define ECF_H
 
-double DeltaR2(fastjet::PseudoJet j1, fastjet::PseudoJet j2) {
-  return DeltaR2(j1.eta(),j1.phi(),j2.eta(),j2.phi());
-}
+/**
+ * \brief delta-r-squared metric between two pseudojets
+ * @param  j1 first jet
+ * @param  j2 second jet
+ * @return    \f$dR^2\f$
+ */
+double DeltaR2(fastjet::PseudoJet j1, fastjet::PseudoJet j2);
 
-void calcECF(double beta, std::vector<fastjet::PseudoJet> &constituents, double *n1=0, double *n2=0, double *n3=0, double *n4=0) {
-  unsigned int nC = constituents.size();
-  double halfBeta = beta/2.;
+/**
+ * \brief Calculates un-normalized ECFs.
+ *
+ * If any of the pointers are not provided (or NULL), that value will not be calculated
+ * @param beta         angular paramater
+ * @param constituents particles with which to calculate the correlations
+ * @param n1           pointer to location of N=1 ECF
+ * @param n2           pointer to location of N=2 ECF
+ * @param n3           pointer to location of N=3 ECF
+ * @param n4           pointer to location of N=4 ECF
+ */
+void calcECF(double beta, std::vector<fastjet::PseudoJet> &constituents, double *n1=0, double *n2=0, double *n3=0, double *n4=0);
 
-  // if only N=1,2, do not bother caching kinematics
-  if (!n3 && !n4) {
-    if (n1) { // N=1
-      double val=0;
-      for (unsigned int iC=0; iC!=nC; ++iC) {    
-        val += constituents[iC].perp();
-      }
-      *n1 = val;
-    }
-    if (n2) { // N=2
-      double val=0;
-      for (unsigned int iC=0; iC!=nC; ++iC) {
-        fastjet::PseudoJet iconst = constituents[iC];
-        for (unsigned int jC=0; jC!=iC; ++jC) {
-          fastjet::PseudoJet jconst = constituents[jC];
-          val += iconst.perp() * jconst.perp() * pow(DeltaR2(iconst,jconst),halfBeta);
-        }
-      }
-      *n2 = val;
-    }
-    return;
-  }
-
-  // cache kinematics
-  std::vector<double> pTs(nC);
-  std::vector<std::vector<double>> dRs(nC);
-  for (unsigned int iC=0; iC!=nC; ++iC) {
-    dRs[iC].resize(iC);
-  }
-
-  for (unsigned int iC=0; iC!=nC; ++iC) {
-    fastjet::PseudoJet iconst = constituents[iC];
-    pTs[iC] = iconst.perp();
-    for (unsigned int jC=0; jC!=iC; ++jC) {
-      fastjet::PseudoJet jconst = constituents[jC];
-      dRs[iC][jC] = pow(DeltaR2(iconst,jconst),halfBeta);
-    }
-  }
-  
-  // now we calculate the real ECFs
-  if (n1) { // N=1
-    double val=0;
-    for (unsigned int iC=0; iC!=nC; ++iC) {    
-      val += pTs[iC];
-    } // iC
-    *n1 = val;
-  }
-  if (n2) { // N=2
-    double val=0;
-    for (unsigned int iC=0; iC!=nC; ++iC) {
-      for (unsigned int jC=0; jC!=iC; ++jC) {
-        val += pTs[iC] * pTs[jC] * dRs[iC][jC]; 
-      } // jC
-    } // iC
-    *n2 = val;
-  }
-  if (n3) {
-    double val=0;
-    for (unsigned int iC=0; iC!=nC; ++iC) {
-      for (unsigned int jC=0; jC!=iC; ++jC) {
-        double val_ij = pTs[iC]*pTs[jC]*dRs[iC][jC];
-        for (unsigned int kC=0; kC!=jC; ++kC) {
-          val += val_ij * pTs[kC] * dRs[iC][kC] * dRs[jC][kC];
-        } // kC
-      } // jC
-    } // iC
-    *n3 = val;
-  }
-  if (n4) {
-    double val=0;
-    for (unsigned int iC=0; iC!=nC; ++iC) {
-      for (unsigned int jC=0; jC!=iC; ++jC) {
-        double val_ij = pTs[iC]*pTs[jC]*dRs[iC][jC];
-        for (unsigned int kC=0; kC!=jC; ++kC) {
-          double val_ijk = val_ij * pTs[kC] * dRs[iC][kC] * dRs[jC][kC];
-          for (unsigned int lC=0; lC!=kC; ++lC) {
-            val += val_ijk * pTs[lC] * dRs[iC][lC] * dRs[jC][lC] * dRs[kC][lC];
-          } // lC
-        } // kC
-      } // jC
-    } // iC
-    *n4 = val;
-  }
-
-}
-
+/**
+ * \brief Just a bunch of floats and bools ot hold different values of normalized ECFs
+ */
 class ECFNManager {
 public:
-  // just a bunch of floats and bools to hold different values of normalized ECFs
   ECFNManager() {
     flags["3_1"]=true; 
     flags["3_2"]=true; 
@@ -115,165 +49,20 @@ public:
   }
   ~ECFNManager() {}
 
-  std::map<TString,double> ecfns; // maps "N_I" to ECFN
-  std::map<TString,bool>   flags; // maps "N_I" to flag
+  std::map<TString,double> ecfns; //!< maps "N_I" to ECFN
+  std::map<TString,bool>   flags; //!< maps "N_I" to flag
 
   bool doN1=true, doN2=true, doN3=true, doN4=true;
 
 };
 
-void calcECFN(double beta, std::vector<fastjet::PseudoJet> &constituents, ECFNManager *manager, bool useMin=true) {
-  unsigned int nC = constituents.size();
-  double halfBeta = beta/2.;
-
-  // get the normalization factor
-  double baseNorm=0; 
-  calcECF(beta,constituents,&baseNorm,0,0,0);
-
-  // cache kinematics
-  std::vector<double> pTs(nC);
-  std::vector<std::vector<double>> dRs(nC);
-  for (unsigned int iC=0; iC!=nC; ++iC) {
-    dRs[iC].resize(iC);
-  }
-
-  for (unsigned int iC=0; iC!=nC; ++iC) {
-    fastjet::PseudoJet iconst = constituents[iC];
-    pTs[iC] = iconst.perp();
-    for (unsigned int jC=0; jC!=iC; ++jC) {
-      fastjet::PseudoJet jconst = constituents[jC];
-      dRs[iC][jC] = pow(DeltaR2(iconst,jconst),halfBeta);
-    }
-  }
-  
-  // now we calculate the ECFNs
-  if (manager->doN1) { // N=1
-    manager->ecfns["1_1"] = 1;
-    manager->ecfns["1_2"] = 1;
-    manager->ecfns["1_3"] = 1;
-  }
-  if (manager->doN2) { // N=2
-    double norm = pow(baseNorm,2);
-    double val=0;
-    for (unsigned int iC=0; iC!=nC; ++iC) {
-      for (unsigned int jC=0; jC!=iC; ++jC) {
-        val += pTs[iC] * pTs[jC] * dRs[iC][jC] / norm; 
-      } // jC
-    } // iC
-    manager->ecfns["2_1"] = val;
-    manager->ecfns["2_2"] = val;
-    manager->ecfns["2_3"] = val;
-  }
-
-  bool doI1=manager->flags["3_1"];
-  bool doI2=manager->flags["3_2"];
-  bool doI3=manager->flags["3_3"];
-  if (manager->doN3 && (doI1||doI2||doI3)) {
-    double norm = pow(baseNorm,3);
-    double val1=0,val2=0,val3=0;
-    unsigned int nAngles=3;
-    std::vector<double> angles(nAngles);
-
-    for (unsigned int iC=0; iC!=nC; ++iC) {
-      for (unsigned int jC=0; jC!=iC; ++jC) {
-        double val_ij = pTs[iC]*pTs[jC];
-        angles[0] = dRs[iC][jC];
-
-        for (unsigned int kC=0; kC!=jC; ++kC) {
-          angles[1] = dRs[iC][kC];
-          angles[2] = dRs[jC][kC];
-
-          if (doI1||doI2||doI3) {
-            double angle_1=999; unsigned int index_1=999;
-            for (unsigned int iA=0; iA!=nAngles; ++iA) {
-              if ((useMin && angles[iA]<angle_1)  || 
-                  (!useMin && angles[iA]>angle_1)) {
-                angle_1 = angles[iA];
-                index_1 = iA;
-              }
-            }
-            if (doI2||doI3) {
-              double angle_2=999; 
-              for (unsigned int jA=0; jA!=nAngles; ++jA) {
-                if (jA==index_1) continue;
-                if ((useMin && angles[jA]<angle_2)  || 
-                    (!useMin && angles[jA]>angle_2)) {
-                  angle_2 = angles[jA];
-                }
-              }
-              if (doI3) {
-                val3 += val_ij * pTs[kC] * angles[0] * angles[1] * angles[2] / norm;
-              }
-              if (doI2)
-                val2 += val_ij * pTs[kC] * angle_1 * angle_2 / norm;
-            }
-            if (doI1)
-              val1 += val_ij * pTs[kC] * angle_1 / norm;
-          }
-
-        } // kC
-      } // jC
-    } // iC
-    manager->ecfns["3_1"] = val1;
-    manager->ecfns["3_2"] = val2;
-    manager->ecfns["3_3"] = val3;
-  }
-
-  doI1=manager->flags["4_1"];
-  doI2=manager->flags["4_2"];
-  if (manager->doN4 && (doI1||doI2)) {
-    double norm = pow(baseNorm,4);
-    double val1=0,val2=0;
-    unsigned int nAngles=6;
-    std::vector<double> angles(nAngles);
-
-    for (unsigned int iC=0; iC!=nC; ++iC) {
-      for (unsigned int jC=0; jC!=iC; ++jC) {
-        double val_ij = pTs[iC]*pTs[jC];
-        angles[0] = dRs[iC][jC];
-
-        for (unsigned int kC=0; kC!=jC; ++kC) {
-          double val_ijk = val_ij * pTs[kC];
-          angles[1] = dRs[iC][kC];
-          angles[2] = dRs[jC][kC];
-
-          for (unsigned int lC=0; lC!=kC; ++lC) {
-            angles[3] = dRs[iC][lC];
-            angles[4] = dRs[jC][lC];
-            angles[5] = dRs[kC][lC];
-
-            if (doI1||doI2) {
-              double angle_1=999; unsigned int index_1=999;
-              for (unsigned int iA=0; iA!=nAngles; ++iA) {
-                if ((useMin && angles[iA]<angle_1)  || 
-                    (!useMin && angles[iA]>angle_1)) {
-                  angle_1 = angles[iA];
-                  index_1 = iA;
-                }
-              }
-              if (doI2) {
-                double angle_2=999; 
-                for (unsigned int jA=0; jA!=nAngles; ++jA) {
-                  if (jA==index_1) continue;
-                  if ((useMin && angles[jA]<angle_2)  || 
-                      (!useMin && angles[jA]>angle_2)) {
-                    angle_2 = angles[jA];
-                  }
-                }
-                val2 += val_ijk * pTs[lC] * angle_1 * angle_2 / norm;
-              }
-              if (doI1)
-                val1 += val_ijk * pTs[lC] * angle_1 / norm;
-            }
-          } // lC
-        } // kC
-      } // jC
-    } // iC
-    manager->ecfns["4_1"] = val1;
-    manager->ecfns["4_2"] = val2;
-    manager->ecfns["4_3"] = 0;
-  }
-
-}
+/**
+ * \brief Calculates normalized energy correlation functions
+ * @param beta         angular parameter
+ * @param constituents particles with which to calculate the correlations
+ * @param manager      provides configuration and storage of ECFNs
+ * @param useMin       DEPRECATED
+ */
+void calcECFN(double beta, std::vector<fastjet::PseudoJet> &constituents, ECFNManager *manager, bool useMin=true);
 
 #endif

--- a/Utilities/src/EnergyCorrelations.cc
+++ b/Utilities/src/EnergyCorrelations.cc
@@ -1,1 +1,254 @@
+/**
+ * \file EnergyCorrelations.cc
+ * \brief Optimized code to calculate energy correlation functions. Based on code from fj-contrib
+ * \author S.Narayanan
+ */
 #include "../interface/EnergyCorrelations.h"
+
+double DeltaR2(fastjet::PseudoJet j1, fastjet::PseudoJet j2) {
+  return DeltaR2(j1.eta(),j1.phi(),j2.eta(),j2.phi());
+}
+
+void calcECF(double beta, std::vector<fastjet::PseudoJet> &constituents, double *n1/*=0*/, double *n2/*=0*/, double *n3/*=0*/, double *n4/*=0*/) {
+  unsigned int nC = constituents.size();
+  double halfBeta = beta/2.;
+
+  // if only N=1,2, do not bother caching kinematics
+  if (!n3 && !n4) {
+    if (n1) { // N=1
+      double val=0;
+      for (unsigned int iC=0; iC!=nC; ++iC) {    
+        val += constituents[iC].perp();
+      }
+      *n1 = val;
+    }
+    if (n2) { // N=2
+      double val=0;
+      for (unsigned int iC=0; iC!=nC; ++iC) {
+        fastjet::PseudoJet iconst = constituents[iC];
+        for (unsigned int jC=0; jC!=iC; ++jC) {
+          fastjet::PseudoJet jconst = constituents[jC];
+          val += iconst.perp() * jconst.perp() * pow(DeltaR2(iconst,jconst),halfBeta);
+        }
+      }
+      *n2 = val;
+    }
+    return;
+  }
+
+  // cache kinematics
+  std::vector<double> pTs(nC);
+  std::vector<std::vector<double>> dRs(nC);
+  for (unsigned int iC=0; iC!=nC; ++iC) {
+    dRs[iC].resize(iC);
+  }
+
+  for (unsigned int iC=0; iC!=nC; ++iC) {
+    fastjet::PseudoJet iconst = constituents[iC];
+    pTs[iC] = iconst.perp();
+    for (unsigned int jC=0; jC!=iC; ++jC) {
+      fastjet::PseudoJet jconst = constituents[jC];
+      dRs[iC][jC] = pow(DeltaR2(iconst,jconst),halfBeta);
+    }
+  }
+  
+  // now we calculate the real ECFs
+  if (n1) { // N=1
+    double val=0;
+    for (unsigned int iC=0; iC!=nC; ++iC) {    
+      val += pTs[iC];
+    } // iC
+    *n1 = val;
+  }
+  if (n2) { // N=2
+    double val=0;
+    for (unsigned int iC=0; iC!=nC; ++iC) {
+      for (unsigned int jC=0; jC!=iC; ++jC) {
+        val += pTs[iC] * pTs[jC] * dRs[iC][jC]; 
+      } // jC
+    } // iC
+    *n2 = val;
+  }
+  if (n3) {
+    double val=0;
+    for (unsigned int iC=0; iC!=nC; ++iC) {
+      for (unsigned int jC=0; jC!=iC; ++jC) {
+        double val_ij = pTs[iC]*pTs[jC]*dRs[iC][jC];
+        for (unsigned int kC=0; kC!=jC; ++kC) {
+          val += val_ij * pTs[kC] * dRs[iC][kC] * dRs[jC][kC];
+        } // kC
+      } // jC
+    } // iC
+    *n3 = val;
+  }
+  if (n4) {
+    double val=0;
+    for (unsigned int iC=0; iC!=nC; ++iC) {
+      for (unsigned int jC=0; jC!=iC; ++jC) {
+        double val_ij = pTs[iC]*pTs[jC]*dRs[iC][jC];
+        for (unsigned int kC=0; kC!=jC; ++kC) {
+          double val_ijk = val_ij * pTs[kC] * dRs[iC][kC] * dRs[jC][kC];
+          for (unsigned int lC=0; lC!=kC; ++lC) {
+            val += val_ijk * pTs[lC] * dRs[iC][lC] * dRs[jC][lC] * dRs[kC][lC];
+          } // lC
+        } // kC
+      } // jC
+    } // iC
+    *n4 = val;
+  }
+
+}
+
+/* TODO: switch from manual sort to std::partial_sort for readability*/
+void calcECFN(double beta, std::vector<fastjet::PseudoJet> &constituents, ECFNManager *manager, bool useMin/*=true*/) {
+  unsigned int nC = constituents.size();
+  double halfBeta = beta/2.;
+
+  // get the normalization factor
+  double baseNorm=0; 
+  calcECF(beta,constituents,&baseNorm,0,0,0);
+
+  // cache kinematics
+  std::vector<double> pTs(nC);
+  std::vector<std::vector<double>> dRs(nC);
+  for (unsigned int iC=0; iC!=nC; ++iC) {
+    dRs[iC].resize(iC);
+  }
+
+  for (unsigned int iC=0; iC!=nC; ++iC) {
+    fastjet::PseudoJet iconst = constituents[iC];
+    pTs[iC] = iconst.perp();
+    for (unsigned int jC=0; jC!=iC; ++jC) {
+      fastjet::PseudoJet jconst = constituents[jC];
+      dRs[iC][jC] = pow(DeltaR2(iconst,jconst),halfBeta);
+    }
+  }
+  
+  // now we calculate the ECFNs
+  if (manager->doN1) { // N=1
+    manager->ecfns["1_1"] = 1;
+    manager->ecfns["1_2"] = 1;
+    manager->ecfns["1_3"] = 1;
+  }
+  if (manager->doN2) { // N=2
+    double norm = pow(baseNorm,2);
+    double val=0;
+    for (unsigned int iC=0; iC!=nC; ++iC) {
+      for (unsigned int jC=0; jC!=iC; ++jC) {
+        val += pTs[iC] * pTs[jC] * dRs[iC][jC]; 
+      } // jC
+    } // iC
+    val /= norm;
+    manager->ecfns["2_1"] = val;
+    manager->ecfns["2_2"] = val;
+    manager->ecfns["2_3"] = val;
+  }
+
+  bool doI1=manager->flags["3_1"];
+  bool doI2=manager->flags["3_2"];
+  bool doI3=manager->flags["3_3"];
+  if (manager->doN3 && (doI1||doI2||doI3)) {
+    double norm = pow(baseNorm,3);
+    double val1=0,val2=0,val3=0;
+    unsigned int nAngles=3;
+    std::vector<double> angles(nAngles);
+
+    for (unsigned int iC=0; iC!=nC; ++iC) {
+      for (unsigned int jC=0; jC!=iC; ++jC) {
+        double val_ij = pTs[iC]*pTs[jC];
+        angles[0] = dRs[iC][jC];
+
+        for (unsigned int kC=0; kC!=jC; ++kC) {
+          angles[1] = dRs[iC][kC];
+          angles[2] = dRs[jC][kC];
+
+          if (doI1||doI2||doI3) {
+            double angle_1=999; unsigned int index_1=999;
+            for (unsigned int iA=0; iA!=nAngles; ++iA) {
+              if (angles[iA]<angle_1) {
+                angle_1 = angles[iA];
+                index_1 = iA;
+              }
+            }
+            if (doI2||doI3) {
+              double angle_2=999; 
+              for (unsigned int jA=0; jA!=nAngles; ++jA) {
+                if (jA==index_1) continue;
+                if (angles[jA]<angle_2) {
+                  angle_2 = angles[jA];
+                }
+              }
+              if (doI3) {
+                val3 += val_ij * pTs[kC] * angles[0] * angles[1] * angles[2];
+              }
+              if (doI2)
+                val2 += val_ij * pTs[kC] * angle_1 * angle_2;
+            }
+            if (doI1)
+              val1 += val_ij * pTs[kC] * angle_1;
+          }
+
+        } // kC
+      } // jC
+    } // iC
+    val1 /= norm; val2 /= norm; val3 /= norm;
+    manager->ecfns["3_1"] = val1;
+    manager->ecfns["3_2"] = val2;
+    manager->ecfns["3_3"] = val3;
+  }
+
+  doI1=manager->flags["4_1"];
+  doI2=manager->flags["4_2"];
+  if (manager->doN4 && (doI1||doI2)) {
+    double norm = pow(baseNorm,4);
+    double val1=0,val2=0;
+    unsigned int nAngles=6;
+    std::vector<double> angles(nAngles);
+
+    for (unsigned int iC=0; iC!=nC; ++iC) {
+      for (unsigned int jC=0; jC!=iC; ++jC) {
+        double val_ij = pTs[iC]*pTs[jC];
+        angles[0] = dRs[iC][jC];
+
+        for (unsigned int kC=0; kC!=jC; ++kC) {
+          double val_ijk = val_ij * pTs[kC];
+          angles[1] = dRs[iC][kC];
+          angles[2] = dRs[jC][kC];
+
+          for (unsigned int lC=0; lC!=kC; ++lC) {
+            angles[3] = dRs[iC][lC];
+            angles[4] = dRs[jC][lC];
+            angles[5] = dRs[kC][lC];
+
+            if (doI1||doI2) {
+              double angle_1=999; unsigned int index_1=999;
+              for (unsigned int iA=0; iA!=nAngles; ++iA) {
+                if (angles[iA]<angle_1) {
+                  angle_1 = angles[iA];
+                  index_1 = iA;
+                }
+              }
+              if (doI2) {
+                double angle_2=999; 
+                for (unsigned int jA=0; jA!=nAngles; ++jA) {
+                  if (jA==index_1) continue;
+                  if (angles[jA]<angle_2) {
+                    angle_2 = angles[jA];
+                  }
+                }
+                val2 += val_ijk * pTs[lC] * angle_1 * angle_2;
+              }
+              if (doI1)
+                val1 += val_ijk * pTs[lC] * angle_1;
+            }
+          } // lC
+        } // kC
+      } // jC
+    } // iC
+    val1 /= norm; val2 /= norm;
+    manager->ecfns["4_1"] = val1;
+    manager->ecfns["4_2"] = val2;
+    manager->ecfns["4_3"] = 0;
+  }
+
+}


### PR DESCRIPTION
- `BaseFiller::reduceEvent` (or `skipEvent`) can be used to skip certain steps if a previous filler says to do so

- `RecoilFilter` implements such a condition, for U>175 GeV. This condition is then read by FatJetFiller and used to skip reclusterings (ECFs, softdrop, tauNSD, HTT). If `RecoilFilter` is not instantiated (configurable), then FatJetFiller accepts everything (`BaseFiller::ReduceEvent()` returns `false` if the pointer is not set)

- For record-keeping, `RecoilFilter` saves two branches for every event: `filter_maxRecoil` and `filter_whichRecoil`, so we can know offline why the decision was made.

- Unrelated: this commit also includes some refactoring and a small performance improvement in the ECF code.