### PR TITLE
Some tweaks to object definitions and filling

### DIFF
--- a/Ntupler/interface/BaseFiller.h
+++ b/Ntupler/interface/BaseFiller.h
@@ -28,6 +28,10 @@ class BaseFiller
          * \brief Reduce the event content if the pointer is set and false
          */
         bool ReduceEvent() { return ((reduceEvent!=0) && (*reduceEvent)); }
+        
+    protected:
+
+        bool firstEntry=true; //!< used by inherited classes to track whether this is the first time analyze() is called
 };
 }
 #endif

--- a/Ntupler/plugins/Ntupler.cc
+++ b/Ntupler/plugins/Ntupler.cc
@@ -250,6 +250,8 @@ Ntupler::Ntupler(const edm::ParameterSet& iConfig)
 
 Ntupler::~Ntupler()
 {
+  delete skipEvent;
+  delete reduceEvent;
 }
 
 

--- a/Ntupler/src/EventFiller.cc
+++ b/Ntupler/src/EventFiller.cc
@@ -18,6 +18,8 @@ EventFiller::~EventFiller(){
 
 void EventFiller::init(TTree *t) {
   t->Branch(treename.Data(),&data,99);
+  data->tiggers->resize(trigger_paths.size(),false);
+  data->metfilters->resize(metfilter_paths.size()+3,false);
 }
 
 int EventFiller::analyze(const edm::Event& iEvent){
@@ -46,8 +48,9 @@ int EventFiller::analyze(const edm::Event& iEvent){
 
       unsigned int nP = trigger_paths.size();
       if (data->isData) {
-        data->tiggers->clear(); // just in case, so the next line initializes to false
-        data->tiggers->resize(trigger_paths.size(),false);
+        for (unsigned int jP=0; jP!=nP; ++jP) {
+          data->tiggers->at(jP) = false;
+        }
 
         iEvent.getByToken(trigger_token,trigger_handle);      
         const edm::TriggerNames &tn = iEvent.triggerNames(*trigger_handle);
@@ -68,7 +71,10 @@ int EventFiller::analyze(const edm::Event& iEvent){
       // met filters
       iEvent.getByToken(metfilter_token,metfilter_handle);
       nP = metfilter_paths.size();
-      data->metfilters->resize(nP+3);  // +1 for allrec and +2 for bad ch/pfmu
+      for (unsigned int jP=0; jP!=nP+3; ++jP) {
+        // +1 for allrec and +2 for bad ch/pfmu
+        data->metfilters->at(jP) = false;
+      }
       const edm::TriggerNames &fn = iEvent.triggerNames(*metfilter_handle);
       unsigned int nF = fn.size();
 

--- a/Ntupler/src/EventFiller.cc
+++ b/Ntupler/src/EventFiller.cc
@@ -36,9 +36,8 @@ int EventFiller::analyze(const edm::Event& iEvent){
     if (firstEntry) {
       firstEntry = false;
       if (!data->isData) {
-        // if this is MC, don't bother saving triggers or metfilters
+        // if this is MC, don't bother saving triggers 
         data->tiggers->clear();
-        data->metfilters->clear();
       }
     }
 

--- a/Ntupler/src/EventFiller.cc
+++ b/Ntupler/src/EventFiller.cc
@@ -18,6 +18,7 @@ EventFiller::~EventFiller(){
 
 void EventFiller::init(TTree *t) {
   t->Branch(treename.Data(),&data,99);
+  // resize once when initializing. will be undone once for MC
   data->tiggers->resize(trigger_paths.size(),false);
   data->metfilters->resize(metfilter_paths.size()+3,false);
 }
@@ -31,6 +32,15 @@ int EventFiller::analyze(const edm::Event& iEvent){
     data->lumiNumber    = iEvent.luminosityBlock();
     data->eventNumber   = iEvent.id().event();
     data->isData        = iEvent.isRealData();
+
+    if (firstEntry) {
+      firstEntry = false;
+      if (!data->isData) {
+        // if this is MC, don't bother saving triggers or metfilters
+        data->tiggers->clear();
+        data->metfilters->clear();
+      }
+    }
 
     if (!(data->isData)) {
       iEvent.getByToken(gen_token,gen_handle); 

--- a/Ntupler/test/runNtupler.py
+++ b/Ntupler/test/runNtupler.py
@@ -221,6 +221,8 @@ runMetCorAndUncFromMiniAOD(process,         ## Puppi MET
                             postfix="Puppi")
 process.PandaNtupler.pfmet = cms.InputTag('slimmedMETs','','PandaNtupler')
 process.PandaNtupler.puppimet = cms.InputTag('slimmedMETsPuppi','','PandaNtupler')
+process.MonoXFilter.met = cms.InputTag('slimmedMETs','','PandaNtupler')
+process.MonoXFilter.puppimet = cms.InputTag('slimmedMETsPuppi','','PandaNtupler')
 
 ############ RUN CLUSTERING ##########################
 process.jetSequence = cms.Sequence()

--- a/Ntupler/test/testNtupler.py
+++ b/Ntupler/test/testNtupler.py
@@ -25,7 +25,7 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 # the size of the output by prescaling the report of the event number
 process.MessageLogger.cerr.FwkReport.reportEvery = 10
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(200) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 
 if isData:
    fileList = [
@@ -71,11 +71,9 @@ from CondCore.DBCommon.CondDBSetup_cfi import *
 
 ######## LUMI MASK
 if isData and not options.isGrid and False: ## dont load the lumiMaks, will be called by crab
-    #pass
     import FWCore.PythonUtilities.LumiList as LumiList
-    ## SILVER
-    process.source.lumisToProcess = LumiList.LumiList(filename='/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-260627_13TeV_PromptReco_Collisions15_25ns_JSON_Silver_v2.txt').getVLuminosityBlockRange()
-    print "FIX JSON"
+    process.source.lumisToProcess = LumiList.LumiList(filename='Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt').getVLuminosityBlockRange()
+    print "Using local JSON"
 
 ### LOAD CONFIGURATION
 process.load('PandaProd.Filter.infoProducerSequence_cff')
@@ -227,7 +225,7 @@ process.MonoXFilter.puppimet = cms.InputTag('slimmedMETsPuppi','','PandaNtupler'
 ############ RUN CLUSTERING ##########################
 process.jetSequence = cms.Sequence()
 
-# btag and patify puppi AK$ jets
+# btag and patify puppi AK4 jets
 from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
 from PhysicsTools.PatAlgos.tools.pfTools import *
 
@@ -328,7 +326,7 @@ process.p = cms.Path(
                         process.puppiMETSequence *             # builds all the puppi collections
                         process.egmPhotonIDSequence *          # baseline photon ID for puppi correction
                         process.fullPatMetSequencePuppi *      # puppi MET
-                        # process.monoXFilterSequence *          # filter
+                        process.monoXFilterSequence *          # filter
                         process.jetSequence *                  # patify ak4puppi and do all fatjet stuff
                         process.metfilterSequence *
                         process.PandaNtupler

--- a/Ntupler/test/testNtupler.py
+++ b/Ntupler/test/testNtupler.py
@@ -25,7 +25,7 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 # the size of the output by prescaling the report of the event number
 process.MessageLogger.cerr.FwkReport.reportEvery = 10
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(200) )
 
 if isData:
    fileList = [
@@ -70,7 +70,8 @@ from CondCore.DBCommon.CondDBSetup_cfi import *
 #from CondCore.CondDB.CondDB_cfi import *
 
 ######## LUMI MASK
-if isData and not options.isGrid and False: ## dont load the lumiMaks, will be called by crab
+#if isData and not options.isGrid and False: ## dont load the lumiMaks, will be called by crab
+if isData:
     import FWCore.PythonUtilities.LumiList as LumiList
     process.source.lumisToProcess = LumiList.LumiList(filename='Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt').getVLuminosityBlockRange()
     print "Using local JSON"

--- a/Objects/interface/PFatJet.h
+++ b/Objects/interface/PFatJet.h
@@ -24,18 +24,31 @@ namespace panda
       { }
     ~PFatJet() { for (auto *s : *subjets) delete s; delete subjets; }
 
-    float tau1, tau2, tau3;
-    float mSD, tau1SD=-1, tau2SD=-1, tau3SD=-1;
-    float htt_mass, htt_frec;
+    float tau1, tau2, tau3; //!< N-subjettiness
+    float mSD, tau1SD=-1, tau2SD=-1, tau3SD=-1; //!< groomed quantities
+    float htt_mass, htt_frec; //!< HEPTopTagger quantities
 
-    // beta = .5, 1, 2, 4
-    float ecfs[3][4][4]; // [o-1][N-1][beta] = x
+    float ecfs[3][4][4]; //!< (groomed,normalized) energy correlation functions; 
+                         // [o-1][N-1][beta] = x
+                         // beta = .5, 1, 2, 4
 
+    /**
+     * \brief Get the normalized ECF. Returns -1 if parameters are invalid
+     * \param o_ order, must be 1,2,3
+     * \param N_ N, must be 1,2,3,4
+     * \param ib_ beta index, must be 0,1,2,3
+     */
     float get_ecf(short o_, short N_, int ib_) const {
       if (o_<1 || o_>3 || N_<1 || N_>4 || ib_<0 || ib_>3) 
         return -1;
       return ecfs[o_-1][N_-1][ib_];
     }
+    /**
+     * \brief Set the normalized ECF. Returns 1 if ECFN could not be set
+     * \param o_ order, must be 1,2,3
+     * \param N_ N, must be 1,2,3,4
+     * \param ib_ beta index, must be 0,1,2,3
+     */
     int set_ecf(int o_, int N_, int ib_, float x_) {
       if (o_<1 || o_>3 || N_<1 || N_>4 || ib_<0 || ib_>3) 
         return 1;
@@ -43,7 +56,7 @@ namespace panda
       return 0;
     }
 
-    VJet *subjets;
+    VJet *subjets; //!< vector of subjets, which are really PJet pointers
 
     ClassDef(PFatJet,1)
     

--- a/Objects/interface/PGenParticle.h
+++ b/Objects/interface/PGenParticle.h
@@ -16,7 +16,8 @@ namespace panda
       {}
     ~PGenParticle(){}
     
-    int pdgid, parent;
+    int pdgid;
+    int parent; //!< used to track index of the parent of this particle in a VGenParticle
     ClassDef(PGenParticle,1)
   };
 

--- a/Objects/interface/PJet.h
+++ b/Objects/interface/PJet.h
@@ -29,12 +29,14 @@ namespace panda
     
     float rawPt,csv,qgl;
     float nhf,chf;
-    // std::vector<PPFCand> constituents;
-    // TClonesArray *constituents=0;
-    //VPFCand *constituents;
-    std::vector<UShort_t> *constituents;
+    std::vector<UShort_t> *constituents; //!< indicies of this jet's constituents in a VPFCand
     unsigned int id;
 
+    /**
+     * \brief Get the PPFCand of this jet corresponding to an index
+     * \param ipf index of the PF candidate
+     * \param VPFCand the PF candidate collection from which this jet was clustered
+     */
     PPFCand *getPFCand(unsigned int ipf, VPFCand *vpf) { return vpf->at(constituents->at(ipf)); }
 
     ClassDef(PJet,1)

--- a/Objects/interface/PMET.h
+++ b/Objects/interface/PMET.h
@@ -2,27 +2,25 @@
 #define PANDA_PMET
 
 #include "PObject.h"
-#include <vector>
 
 namespace panda
 {
-  class PMET : public PObject
+  class PMET : public TObject
   {
     public:
-      PMET():
-        PObject()
-      {  }
-    ~PMET(){ }
+      PMET() { }
+      ~PMET(){ }
     
-    float sumETRaw;
-    float raw_pt, raw_phi;
-    float calo_pt, calo_phi;
-    float noMu_pt, noMu_phi;
-    float noHF_pt, noHF_phi;
-    float trk_pt, trk_phi;
-    float neutral_pt, neutral_phi;
-    float photon_pt, photon_phi;
-    float hf_pt, hf_phi;
+    float pt=0, phi=0;                 //!< type-1 corrected MET
+    float sumETRaw;                    //!< sum E_T, uncorrected
+    float raw_pt=0, raw_phi=0;         //!< raw, uncorrected
+    float calo_pt=0, calo_phi=0;       //!< calorimeter-only
+    float noMu_pt=0, noMu_phi=0;       //!< without muons
+    float noHF_pt=0, noHF_phi=0;       //!< without HF
+    float trk_pt=0, trk_phi=0;         //!< tracks only
+    float neutral_pt=0, neutral_phi=0; //!< neutral particles only
+    float photon_pt=0, photon_phi=0;   //!< photons only
+    float hf_pt=0, hf_phi=0;           //!< HF only
 
     ClassDef(PMET,1)
   };

--- a/Objects/interface/PObject.h
+++ b/Objects/interface/PObject.h
@@ -3,7 +3,7 @@
 
 #include "PandaUtilities/Common/interface/Common.h"
 #include <TObject.h>
-#include <TClonesArray.h>
+#include <TLorentzVector.h>
 
 
 namespace panda
@@ -17,14 +17,38 @@ namespace panda
         phi(0),
         m(0)
         {}
-    ~PObject(){}
+      ~PObject(){ delete cachedP4; }
+
+      /**
+       * \brief Return a 4-vector for this object
+       * \param refreshCache if true or if the cache does not exist, the 4-vector will be recomputed
+       *
+       * Builds and caches a TLorentzVector for this object. On next call, the 4-vector
+       * can be re-used
+       */
+      TLorentzVector *p4(bool refreshCache=false) {
+        if (refreshCache || cachedP4==0) {
+          delete cachedP4;
+          cachedP4 = new TLorentzVector();
+          cachedP4->SetPtEtaPhiM(pt,eta,phi,m);
+        }
+        return cachedP4;
+      }
     
     float pt,eta, phi, m;
+
+    private:
+      TLorentzVector *cachedP4=0; //!< cached 4-vector constructed on-demand
+
     ClassDef(PObject,1)
   };
 
+  /**
+   * \brief Order two PObject pointers by pT
+   */
   inline bool SortPObjects(PObject *o1, PObject *o2) {
     return o1->pt > o2->pt;
   }
+
 }
 #endif


### PR DESCRIPTION
- Assuming triggers/metfilters are the same for each event, so only resize once

- Adding `PObject::p4()` to construct and cache a 4-vector

- `PMET` no longer inherits from `PObject` to avoid saving unnecessary `eta` and `m`

- Improving documentation of jet/MET stuff